### PR TITLE
Disable http basic auth when no credentials are set the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ daemon.yml configuration:
 | key |  |
 |-----|---------|
 app.path | Filesystem path to the rails app being perf check'd. The app should be setup to run in development mode, and have `gem "perf_check"` bundled.
+credentials.user | User used for HTTP basic auth on /status page (optional).
+credentials.password | Password used for HTTP basic auth on /status page (optional).
 limits.change_factor | Factor of change in latency before a warning is added to the pull request comment.
 limits.latency | Absolute response time allowed before a warning is added to the pull request comment.
 limits.queries | Number of queries allowed before a warning is added to the pull request comment.

--- a/lib/perf_check_daemon/app.rb
+++ b/lib/perf_check_daemon/app.rb
@@ -21,7 +21,7 @@ module PerfCheckDaemon
     set :root, File.expand_path("#{File.dirname(__FILE__)}/../..")
 
     get "/" do
-      "Hello World!"
+      redirect '/status'
     end
 
     # pull_request

--- a/lib/perf_check_daemon/status_app.rb
+++ b/lib/perf_check_daemon/status_app.rb
@@ -202,13 +202,15 @@ module PerfCheckDaemon
     end
 
     before // do
-      auth = Rack::Auth::Basic::Request.new(request.env)
-      credentials = config.credentials
-      credentials &&= [config.credentials.user, config.credentials.password]
-      auth_basic = auth.provided? && auth.basic? && auth.credentials
-      unless auth_basic && auth.credentials == credentials
-        headers['WWW-Authenticate'] = 'Basic realm="Restricted Area"'
-        halt 401, "Not authorized\n"
+      unless config.credentials.password.blank? && config.credentials.user.blank?
+        auth = Rack::Auth::Basic::Request.new(request.env)
+        credentials = config.credentials
+        credentials &&= [config.credentials.user, config.credentials.password]
+        auth_basic = auth.provided? && auth.basic? && auth.credentials
+        unless auth_basic && auth.credentials == credentials
+          headers['WWW-Authenticate'] = 'Basic realm="Restricted Area"'
+          halt 401, "Not authorized\n"
+        end
       end
     end
   end


### PR DESCRIPTION
When no user/password credentials aren't set in the config don't use http basic auth.